### PR TITLE
Fix license badge in README.md to be lower case

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
   </a>
   <!-- License -->
   <a href="https://opensource.org/licenses/BSD-3-Clause">
-    <img src="https://img.shields.io/badge/License-BSD%203--Clause-blue.svg" alt="bsd_3_license">
+    <img src="https://img.shields.io/badge/license-BSD%203--Clause-blue.svg" alt="bsd_3_license">
   </a>
 </p>
 


### PR DESCRIPTION


<!-- readthedocs-preview frouros start -->
----
:books: Documentation preview :books:: https://frouros--244.org.readthedocs.build/en/244/

<!-- readthedocs-preview frouros end -->