### PR TITLE
Fix remove callbacks kwargs

### DIFF
--- a/frouros/callbacks/base.py
+++ b/frouros/callbacks/base.py
@@ -3,6 +3,8 @@
 import abc
 from typing import Optional
 
+import numpy as np  # type: ignore
+
 
 class BaseCallback(abc.ABC):
     """Abstract class representing a callback."""
@@ -55,11 +57,19 @@ class BaseCallback(abc.ABC):
     #         )
     #     self._detector = value
 
-    def on_fit_start(self, **kwargs) -> None:
-        """On fit start method."""
+    def on_fit_start(self, X: np.ndarray) -> None:  # noqa: N803
+        """On fit start method.
 
-    def on_fit_end(self, **kwargs) -> None:
-        """On fit end method."""
+        :param X: reference data
+        :type X: numpy.ndarray
+        """
+
+    def on_fit_end(self, X: np.ndarray) -> None:  # noqa: N803
+        """On fit end method.
+
+        :param X: reference data
+        :type X: numpy.ndarray
+        """
 
     @abc.abstractmethod
     def reset(self) -> None:

--- a/frouros/callbacks/batch/base.py
+++ b/frouros/callbacks/batch/base.py
@@ -1,6 +1,9 @@
 """Base callback batch module."""
 
 import abc
+from typing import Any
+
+import numpy as np  # type: ignore
 
 from frouros.callbacks.base import BaseCallback
 
@@ -8,11 +11,34 @@ from frouros.callbacks.base import BaseCallback
 class BaseCallbackBatch(BaseCallback):
     """Callback batch class."""
 
-    def on_compare_start(self, **kwargs) -> None:
-        """On compare start method."""
+    def on_compare_start(
+        self,
+        X_ref: np.ndarray,  # noqa: N803
+        X_test: np.ndarray,
+    ) -> None:
+        """On compare start method.
 
-    def on_compare_end(self, **kwargs) -> None:
-        """On compare end method."""
+        :param X_ref: reference data
+        :type X_ref: numpy.ndarray
+        :param X_test: test data
+        :type X_test: numpy.ndarray
+        """
+
+    def on_compare_end(
+        self,
+        result: Any,
+        X_ref: np.ndarray,  # noqa: N803
+        X_test: np.ndarray,
+    ) -> None:
+        """On compare end method.
+
+        :param result: result obtained from the `compare` method
+        :type result: Any
+        :param X_ref: reference data
+        :type X_ref: numpy.ndarray
+        :param X_test: test data
+        :type X_test: numpy.ndarray
+        """
 
     # FIXME: set_detector method as a workaround to  # pylint: disable=fixme
     #  avoid circular import problem. Make it an abstract method and

--- a/frouros/callbacks/batch/permutation_test.py
+++ b/frouros/callbacks/batch/permutation_test.py
@@ -148,10 +148,22 @@ class PermutationTestDistanceBased(BaseCallbackBatch):
         p_value = (permuted_statistic >= observed_statistic).mean()  # type: ignore
         return permuted_statistic, p_value
 
-    def on_compare_end(self, **kwargs) -> None:
-        """On compare end method."""
-        X_ref, X_test = kwargs["X_ref"], kwargs["X_test"]  # noqa: N806
-        observed_statistic = kwargs["result"][0]
+    def on_compare_end(
+        self,
+        result: Any,
+        X_ref: np.ndarray,  # noqa: N803
+        X_test: np.ndarray,
+    ) -> None:
+        """On compare end method.
+
+        :param result: result obtained from the `compare` method
+        :type result: Any
+        :param X_ref: reference data
+        :type X_ref: numpy.ndarray
+        :param X_test: test data
+        :type X_test: numpy.ndarray
+        """
+        observed_statistic = result.distance
         permuted_statistics, p_value = self._calculate_p_value(
             X_ref=X_ref,
             X_test=X_test,

--- a/frouros/callbacks/batch/reset.py
+++ b/frouros/callbacks/batch/reset.py
@@ -1,6 +1,8 @@
 """Reset batch callback module."""
 
-from typing import Optional
+from typing import Any, Optional
+
+import numpy as np  # type: ignore
 
 from frouros.callbacks.batch.base import BaseCallbackBatch
 from frouros.utils.logger import logger
@@ -58,10 +60,23 @@ class ResetStatisticalTest(BaseCallbackBatch):
             raise ValueError("value must be greater than 0.")
         self._alpha = value
 
-    def on_compare_end(self, **kwargs) -> None:
-        """On compare end method."""
-        p_value = kwargs["result"].p_value
-        if p_value < self.alpha:
+    def on_compare_end(
+        self,
+        result: Any,
+        X_ref: np.ndarray,  # noqa: N803
+        X_test: np.ndarray,
+    ) -> None:
+        """On compare end method.
+
+        :param result: result obtained from the `compare` method
+        :type result: Any
+        :param X_ref: reference data
+        :type X_ref: numpy.ndarray
+        :param X_test: test data
+        :type X_test: numpy.ndarray
+        """
+        p_value = result.p_value
+        if p_value <= self.alpha:
             logger.info("Drift detected. Resetting detector...")
             self.detector.reset()  # type: ignore
 

--- a/frouros/callbacks/streaming/base.py
+++ b/frouros/callbacks/streaming/base.py
@@ -1,6 +1,7 @@
 """Base callback streaming module."""
 
 import abc
+from typing import Union
 
 from frouros.callbacks.base import BaseCallback
 
@@ -8,11 +9,19 @@ from frouros.callbacks.base import BaseCallback
 class BaseCallbackStreaming(BaseCallback):
     """Callback streaming class."""
 
-    def on_update_start(self, **kwargs) -> None:
-        """On update start method."""
+    def on_update_start(self, value: Union[int, float]) -> None:
+        """On update start method.
 
-    def on_update_end(self, **kwargs) -> None:
-        """On update end method."""
+        :param value: value used to update the detector
+        :type value: Union[int, float]
+        """
+
+    def on_update_end(self, value: Union[int, float]) -> None:
+        """On update end method.
+
+        :param value: value used to update the detector
+        :type value: Union[int, float]
+        """
 
     # FIXME: set_detector method as a workaround to  # pylint: disable=fixme
     #  avoid circular import problem. Make it an abstract method and

--- a/frouros/callbacks/streaming/history.py
+++ b/frouros/callbacks/streaming/history.py
@@ -1,6 +1,6 @@
 """History callback module."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from frouros.callbacks.streaming.base import BaseCallbackStreaming
 from frouros.utils.stats import BaseStat
@@ -62,9 +62,13 @@ class HistoryConceptDrift(BaseCallbackStreaming):
         self.additional_vars.extend(vars_)
         self.history = {**self.history, **{var: [] for var in self.additional_vars}}
 
-    def on_update_end(self, **kwargs) -> None:
-        """On update end method."""
-        self.history["value"].append(kwargs["value"])
+    def on_update_end(self, value: Union[int, float]) -> None:
+        """On update end method.
+
+        :param value: value used to update the detector
+        :type value: Union[int, float]
+        """
+        self.history["value"].append(value)
         self.history["num_instances"].append(
             self.detector.num_instances  # type: ignore
         )

--- a/frouros/detectors/concept_drift/base.py
+++ b/frouros/detectors/concept_drift/base.py
@@ -184,17 +184,17 @@ class BaseConceptDrift(BaseDetector):
 
         :param value: value to update detector
         :type value: Union[int, float]
+        :return: callbacks logs
+        :rtype: Dict[str, Any]]
         """
         for callback in self.callbacks:  # type: ignore
             callback.on_update_start(  # type: ignore
                 value=value,
-                **kwargs,
             )
         self._update(value=value, **kwargs)
         for callback in self.callbacks:  # type: ignore
             callback.on_update_end(  # type: ignore
                 value=value,
-                **kwargs,
             )
 
         callbacks_logs = self._get_callbacks_logs()

--- a/frouros/detectors/data_drift/base.py
+++ b/frouros/detectors/data_drift/base.py
@@ -187,17 +187,15 @@ class BaseDataDrift(BaseDetector):
         for callback in self.callbacks:  # type: ignore
             callback.on_fit_start(
                 X=X,
-                **kwargs,
             )
         self._fit(X=X, **kwargs)
         for callback in self.callbacks:  # type: ignore
             callback.on_fit_end(
                 X=X,
-                **kwargs,
             )
 
-        logs = self._get_callbacks_logs()
-        return logs
+        callbacks_logs = self._get_callbacks_logs()
+        return callbacks_logs
 
     def reset(self) -> None:
         """Reset method."""

--- a/frouros/detectors/data_drift/batch/base.py
+++ b/frouros/detectors/data_drift/batch/base.py
@@ -60,7 +60,7 @@ class BaseDataDriftBatch(BaseDataDrift):
     ) -> Tuple[np.ndarray, Dict[str, Any]]:
         """Compare values.
 
-        :param X: feature data
+        :param X: test data
         :type X: numpy.ndarray
         :return: compare result and callbacks logs
         :rtype: Tuple[numpy.ndarray, Dict[str, Any]]

--- a/frouros/detectors/data_drift/streaming/base.py
+++ b/frouros/detectors/data_drift/streaming/base.py
@@ -56,27 +56,29 @@ class BaseDataDriftStreaming(BaseDataDrift):
         self._reset()
 
     def update(
-        self, value: Union[int, float]
+        self,
+        value: Union[int, float],
     ) -> Tuple[Optional[BaseResult], Dict[str, Any]]:
         """Update detector.
 
         :param value: value to use to update the detector
         :type value: Union[int, float]
-        :return: update result
-        :rtype: Optional[BaseResult]
+        :return: update result and callbacks logs
+        :rtype: Tuple[Optional[BaseResult], Dict[str, Any]]
         """
         self._common_checks()  # noqa: N806
         self._specific_checks(X=value)  # noqa: N806
         self.num_instances += 1
 
         for callback in self.callbacks:  # type: ignore
-            callback.on_update_start(value=value)  # type: ignore
+            callback.on_update_start(  # type: ignore
+                value=value,  # type: ignore
+            )
         result = self._update(value=value)
-        if result is not None:
-            for callback in self.callbacks:  # type: ignore
-                callback.on_update_end(  # type: ignore
-                    value=result.distance,  # type: ignore
-                )
+        for callback in self.callbacks:  # type: ignore
+            callback.on_update_end(  # type: ignore
+                value=result,  # type: ignore
+            )
 
         callbacks_logs = self._get_callbacks_logs()
         return result, callbacks_logs


### PR DESCRIPTION
Remove the possibility to pass kwargs to each callback on_ function. Instead, set fixed variables for each callback on_ function.
Adapt each existing callbacks to this new behavior. 

<!-- readthedocs-preview frouros start -->
----
:books: Documentation preview :books:: https://frouros--261.org.readthedocs.build/en/261/

<!-- readthedocs-preview frouros end -->